### PR TITLE
Fix removeClass() with no arguments not removing all classes

### DIFF
--- a/jquery.removeClass.js
+++ b/jquery.removeClass.js
@@ -16,7 +16,7 @@
 				}
 			}
 		} else {
-			removeClass.call(this, value);
+			removeClass.apply(this, Array.prototype.slice.apply(arguments));
 		}
 		return this;
 	}

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,7 @@
 	<title>jquery.removeClass and jquery.hasClass tests</title>
 	<link rel="stylesheet" href="qunit/qunit.css">
 	<script src="qunit/qunit.js"></script>
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.js"></script>
 	<script src="../jquery.removeClass.js"></script>
 	<script src="removeClass.test.js"></script>
 	<script src="../jquery.hasClass.js"></script>

--- a/test/removeClass.test.js
+++ b/test/removeClass.test.js
@@ -41,3 +41,9 @@ test("string", function() {
 	elem.removeClass("disabled state-open");
 	equal(elem[0].className, "");
 });
+
+test("empty params", function() {
+	var elem = jQuery("<div class='state-open state-loading disabled'/>");
+	elem.removeClass();
+	equal(elem[0].className, "");
+});


### PR DESCRIPTION
Fixes #2 (calling `removeClass()` with no arguments does not remove all classes).

jQuery's behavior changed somewhere between 1.4.4 and 1.11.3; the 'empty' test
case works against 1.4.4 but not 1.11.3 or 2.1.4.  Changing the fallback case
to pass along the original arguments fixes the issue.
